### PR TITLE
gh #6 Updated hyperlinks in v4l2_halSpec.md

### DIFF
--- a/docs/pages/v4l2_halSpec.md
+++ b/docs/pages/v4l2_halSpec.md
@@ -1,11 +1,5 @@
 # V4L2 Documentation
 
-## Version History
-
-| Date [DD/MM/YY] | Comment | Version |
-| --- | --- | --- |
-| 08/08/23 | First Release | 1.0.0 |
-
 ## Table of Contents
 
 - [Acronyms, Terms and Abbreviations](#acronyms-terms-and-abbreviations)
@@ -13,7 +7,7 @@
   - [Introduction](#introduction)
   - [References](#references)
 - [Component Runtime Execution Requirements](#component-runtime-execution-requirements)
-  - [Initialization and Startup](#initializatio-and-startup)
+  - [Initialization and Startup](#initialization-and-startup)
   - [Threading Model](#threading-model)
   - [Process Model](#process-model)
   - [Memory Model](#memory-model)
@@ -37,7 +31,6 @@
     - [IOCTL Call Flow when capturing images](#ioctl-call-flow-when-capturing-images)
     - [General IOCTL Call Flow](#general-ioctl-call-flow)
 
-
 ## Acronyms, Terms and Abbreviations
 
 - `HAL`    - Hardware Abstraction Layer
@@ -47,8 +40,8 @@
 - `V4L2`   - Video For Linux version 2
 - `IOCTL`  - Input-Output Control
 
-
 ## Description
+
 This interface provides a set of `IOCTL` calls that are required to be supported by the `SoC's` `V4L2` driver. Any of the layers calling the `V4L2`, must be referred as `caller`.
 The diagram below shows the interaction between `caller` and `SoC` `V4L2` Driver.
 
@@ -61,33 +54,41 @@ style B fill:#fcc,stroke:#333
 ```
 
 ### Introduction
+
 The `V4L2` functionality enables video playback applications to easily display video content on a variety of embedded Linux devices with different video output capabilities. `V4L2` framework provides a standardized and flexible interface for working with video devices on Linux-based systems. By providing a common `API` for accessing and controlling video devices, `V4L2` simplifies the development of video applications and drivers, and enables interoperability across different hardware platforms and drivers.
 
 For example, when a user-space application requests a video frame, the `V4L2` driver captures the frame from the device using the configured communication channels and stores it in a buffer. The user-space application can then read the frame from the buffer and process it as needed. Similarly, when a user-space application requests output to a display device, the `V4L2` driver outputs the video frames to the appropriate destination. During video playback, the video frames are sent to the video output device using the `V4L2` `IOCTL` calls which handles the low-level details of displaying the frames on the screen.
 
 ### References
+
 Video4Linux Devices Specifications - [Video4Linux devices](https://www.kernel.org/doc/html/v5.4/media/kapi/v4l2-core.html "Video4Linux devices")
 
+### Component Runtime Execution Requirements
 
-## Component Runtime Execution Requirements
 These requirements ensure that the `HAL` executes correctly within the run-time environment that it will be used in. Failure to meet these requirements will likely result in undefined and unexpected behaviour.
 
 ### Initialization and Startup
+
 The `V4L2` driver provides the interface between the `caller` and the video device. Once the `caller` successfully opens the video device file (available as /dev/videoX; where X is a non-negative integer) with read and write permissions (`O_RDWR`) using the `open()` system call and sets the `O_CLOEXEC` flag, it will then use subsequent `V4L2`-specific `IOCTL` calls to interact with the driver and perform operations. With `VIDIOC_QUERYCAP` the `caller` will get the device hardware capabilities.
 
 ### Threading Model
+
 `HAL` shall be thread safe. Any `caller` invoking the `IOCTLs` must ensure calls are made in a thread safe manner. There is no restriction on the vendor to create any number of threads to meet the operational requirements.
 
 ### Process Model
+
 This interface supports multiple instantiation with a single process. The `V4L2` driver is expected to support multiple opens. `EBUSY` will be returned if the driver does not support multiple opens and the device is already in use. Merely opening a `V4L2` device does not grant exclusive access. Initiating data exchange however, assigns the right to read or write the requested type of data and to change related properties, to this file descriptor. `Caller` can request additional access privileges using the priority mechanism. Refer [<b>this link</b>.](https://www.kernel.org/doc/html/next/userspace-api/media/v4l/open.html "Multiple Opens")
 
 ### Memory Model
+
 The memory model of this interface needs to be taken care by the `SoC's` `V4L2` driver only, with respect to the `IOCTL` calls which are required by the `caller`. By utilizing these `IOCTL` calls, `caller` will interact with `V4L2` and manage the memory model for the video frames. The choice of memory type chosen by the `caller` and `V4L2` driver must be able to support at least these two memory types: `V4L2_MEMORY_MMAP` and `V4L2_MEMORY_DMABUF`.
 
 ### Power Management Requirements
+
 There is no requirement for the component to participate in power management. In general, the `SoC` `V4L2` driver must be designed to minimize the power consumption of the device.
 
 ### Asynchronous Notification Model
+
 The following `IOCTL` calls, namely `VIDIOC_SUBSCRIBE_EVENT`, `VIDIOC_UNSUBSCRIBE_EVENT` and `VIDIOC_DQEVENT` support an asynchronous notification model as they enable the `caller` to receive video events asynchronously, indicating changes or occurrences in the video device or system. Other `IOCTLs` primarily involve configuration, control, streaming, buffer management, or retrieval of information, but they do not have built-in mechanisms for asynchronous event handling or notifications.
 
 -  <b>`VIDIOC_SUBSCRIBE_EVENT`:</b> This `IOCTL` call allows the `caller` to subscribe to video events generated by a video device asynchronously. Once subscribed, the `caller` can receive notifications about specific events asynchronously, indicating changes or occurrences in the video device.
@@ -99,22 +100,26 @@ The following `IOCTL` calls, namely `VIDIOC_SUBSCRIBE_EVENT`, `VIDIOC_UNSUBSCRIB
 The `V4L2` driver is required to support at least these four event types: `V4L2_EVENT_ALL`, `V4L2_EVENT_SRC_CH_RESOLUTION`, `V4L2_EVENT_SOURCE_CHANGE` and `V4L2_EVENT_EOS`. Refer: [V4L2 Event Types](https://www.kernel.org/doc/html/v5.4/media/uapi/v4l/vidioc-dqevent.html#event-type "V4L2 Event Types")
 
 ### Blocking calls
+
 None of the calls in the interface must block.
 
 ### Internal Error Handling
-All the `IOCTLs` must return error synchronously as a return argument. Please refer to [<b>V4L2 General Errors</b>](https://www.kernel.org/doc/html/v5.4/media/uapi/gen-errors.html. "V4L2 General Errors").
+
+All the `IOCTLs` must return error synchronously as a return argument. Please refer to [<b>V4L2 General Errors</b>](https://www.kernel.org/doc/html/v5.4/media/uapi/gen-errors.html "V4L2 General Errors").
 `HAL` is responsible for handling system errors (e.g. out of memory) internally.
 
 ### Persistence Model
-There is no requirement for the interface to persist any setting information. 
 
+There is no requirement for the interface to persist any setting information.
 
 ## Non-functional requirements
 
 ### Logging and debugging requirements
+
 This interface is required to support DEBUG, INFO and ERROR messages. ERROR logs must be enabled by default. DEBUG and INFO is required to be disabled by default and enabled when needed.
 
 ### Memory and performance requirements
+
 This interface is required to not cause excessive memory and CPU utilization.
 
 ### Quality Control
@@ -127,23 +132,29 @@ This interface is required to not cause excessive memory and CPU utilization.
 - Improvements by any party to the testing suite are required to be fed back.
 
 ### Licensing
+
 The `HAL` implementation is expected to released under the Apache License 2.0.
 
 ### Build Requirements
+
 `V4L2` driver will be implemented as a kernel module. `SoC` team is expected to handle the compilation of `V4L2` driver as part of kernel and need to enable the configuration options required for adding `V4L2` driver in the kernel for supporting V4L protocol based decoding components. The driver modules plug into the videodev kernel module. Also, the driver's linux kernel is expected to be at least `5.4.0`. Refer [<b>this link</b>](https://www.kernelconfig.io/index.html "Kernel configuration") for necessary configuration options.
 
 The build mechanism must be independent of Yocto.
 
 ### Variability Management
+
 Any changes in the `APIs` must be reviewed and approved by the component architects. Further support may be added to test any specific requirements of the target platform or product.
 
 ### Platform or Product Customization
+
 This interface is not required to have any platform or product customizations.
 
 ## Interface API Documentation
+
 `API` documentation will be provided by Doxygen which will be generated from the header files.
 
 ### Theory of operation and key concepts
+
 The `caller` is expected to have complete control over calling the `V4L2` `IOCTLs`.
 
 Operation of `V4L2` typically involves the following steps:
@@ -159,6 +170,8 @@ Operation of `V4L2` typically involves the following steps:
 - <b>Stream Activation:</b>  Once the device is properly configured and memory buffers are allocated, the `V4L2` interface activates the video stream using `VIDIOC_STREAMON`. This step starts the flow of video frames from the device to the allocated memory buffers, allowing the `caller` to access and process the captured video data.
 
 - <b>Data Processing and Utilization:</b> Once the video stream is active, the `caller` can retrieve the captured video frames from the memory buffers and process them for various purposes. This may include displaying the video feed on a screen using `VIDIOC_DQBUF`, saving the video to a file, performing real-time analysis, or integrating the video data into other applications.
+
+### V4L2 IOCTL for SOC Implementation
 
 For `SoC` Implementation, `V4L2` driver is required to support these `19` `IOCTL` calls:
 


### PR DESCRIPTION
https://github.com/rdkcentral/rdk-halif-v4l2/blob/main/docs/pages/v4l2_halSpec.md

Change reason1: Typo in title (‘n’ at the end of initialization missing ) resulting in a failing hyperlink
Change reason2: A period (‘.’ ) at the end of URL in hyperlink resulting in a 404
Section Title is given at the top in Table of contents, but not given later in document, resulting in a deadlink